### PR TITLE
A0-3315: Add a warning for all occurrences of github variable in double quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ issue occurs in a workflow.
 | Code | Description |
 |------|-------------|
 | WW101 | Called env var '%s' not found in global, job or step 'env' block - check it |
+| WW201 | Called var '%s' may not need to be in double quotes |
 
 ### Naming convention warnings
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/Cardinal-Cryptography/github-actions-validator
 
 go 1.19
 
-require github.com/MikolajGasior/go-mod-cli v1.0.0
-
-require gopkg.in/yaml.v2 v2.4.0
+require (
+	github.com/bitsnops/go-broccli v1.1.0
+	gopkg.in/yaml.v2 v2.4.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/MikolajGasior/go-mod-cli v1.0.0 h1:YNP1TnQgKGFw9KF1Zgf+2PLPr445kzjxHPl1rZgIRak=
-github.com/MikolajGasior/go-mod-cli v1.0.0/go.mod h1:M4KyBYxD8cWYLuB62FTs/Ng4pkyqcuOjnQlAYWidyic=
+github.com/bitsnops/go-broccli v1.1.0 h1:aSIbHayHi7m8bD9pbh40/pNa9HxUvMFGwMmPf9rKfxA=
+github.com/bitsnops/go-broccli v1.1.0/go.mod h1:rGxWdzSbu6/BMH7lkWBNPGSixhlmSW1kK7K+a1RJKwo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	gocli "github.com/MikolajGasior/go-mod-cli"
+	gocli "github.com/bitsnops/go-broccli"
 	"os"
 
 	"github.com/Cardinal-Cryptography/github-actions-validator/pkg/dotgithub"

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -89,6 +89,12 @@ func (a *Action) Validate(d IDotGithub) ([]string, error) {
 	}
 	validationErrors = a.appendErrs(validationErrors, verrs)
 
+	verrs, err = a.validateCalledVarsNotInDoubleQuotes()
+	if err != nil {
+		return validationErrors, err
+	}
+	validationErrors = a.appendErrs(validationErrors, verrs)
+
 	verrs, err = a.validateSteps(d)
 	if err != nil {
 		return validationErrors, err
@@ -230,6 +236,16 @@ func (a *Action) validateCalledStepOutputs() ([]string, error) {
 				validationErrors = append(validationErrors, a.formatError("EA204", fmt.Sprintf("Called step with id '%s' does not exist", string(f[1]))))
 			}
 		}
+	}
+	return validationErrors, nil
+}
+
+func (a *Action) validateCalledVarsNotInDoubleQuotes() ([]string, error) {
+	var validationErrors []string
+	re := regexp.MustCompile(`\"\${{[ ]*([a-zA-Z0-9\\-_.]+)[ ]*}}\"`)
+	found := re.FindAllSubmatch(a.Raw, -1)
+	for _, f := range found {
+		validationErrors = append(validationErrors, a.formatError("WW201", fmt.Sprintf("Called variable '%s' may not need to be in double quotes", string(f[1]))))
 	}
 	return validationErrors, nil
 }

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.5.4"
+const VERSION = "0.5.0"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.4.4"
+const VERSION = "0.5.4"


### PR DESCRIPTION
When `"${{ some.variable }}"` is found the actions or workflows, validator will throw a warning `Called variable '%s' may not need to be in double quotes`.

This cannot be error as there might be cases where double quote is actually necessary.

GitHub variable do not need double quote.  Also an unknown input or output (from another step) can have a back tick sign which can cause command execution in bash, or dollar sign that can cause injecting a value.  So basically, it's a good practice.